### PR TITLE
Implement listing_type column and square_feet updates

### DIFF
--- a/backend/crud/properties.py
+++ b/backend/crud/properties.py
@@ -49,9 +49,9 @@ class CRUDProperty:
         if max_bathrooms is not None:
             query = query.filter(models.Property.bathrooms <= max_bathrooms)
         if min_area is not None:
-            query = query.filter(models.Property.area >= min_area)
+            query = query.filter(models.Property.square_feet >= min_area)
         if max_area is not None:
-            query = query.filter(models.Property.area <= max_area)
+            query = query.filter(models.Property.square_feet <= max_area)
 
         return query.offset(skip).limit(limit).all()
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -52,6 +52,7 @@ class Property(Base):
     bathrooms = Column(Integer)
     square_feet = Column(Integer)
     property_type = Column(String)  # e.g., 'House', 'Apartment', 'Condo'
+    listing_type = Column(String, nullable=True)
     status = Column(String, default="available")  # e.g., 'available', 'sold', 'pending'
     image_url = Column(String, nullable=True) 
     latitude = Column(Float, nullable=True)

--- a/frontend/pages/admin/properties/edit/[id].js
+++ b/frontend/pages/admin/properties/edit/[id].js
@@ -27,7 +27,7 @@ export default function EditPropertyPage() {
     listing_type: listingTypes[0],
     bedrooms: '',
     bathrooms: '',
-    area: '',
+    square_feet: '',
     latitude: '10.4806',
     longitude: '-66.9036',
     is_featured: false,
@@ -82,7 +82,7 @@ export default function EditPropertyPage() {
         listing_type: propertyData.listing_type || listingTypes[0],
         bedrooms: propertyData.bedrooms || '',
         bathrooms: propertyData.bathrooms || '',
-        area: propertyData.area || '',
+        square_feet: propertyData.square_feet || '',
         latitude: propertyData.latitude?.toString() || '10.4806',
         longitude: propertyData.longitude?.toString() || '-66.9036',
         is_featured: propertyData.is_featured || false,
@@ -197,7 +197,7 @@ export default function EditPropertyPage() {
       price: parseFloat(formData.price) || 0,
       bedrooms: formData.bedrooms !== '' ? parseInt(formData.bedrooms) : null,
       bathrooms: formData.bathrooms !== '' ? parseInt(formData.bathrooms) : null,
-      area: formData.area !== '' ? parseFloat(formData.area) : null,
+      square_feet: formData.square_feet !== '' ? parseFloat(formData.square_feet) : null,
       latitude: formData.latitude !== '' ? parseFloat(formData.latitude) : null,
       longitude: formData.longitude !== '' ? parseFloat(formData.longitude) : null,
       image_url: newMainImageUrl === '' ? null : newMainImageUrl, // Convert '' to null
@@ -259,7 +259,7 @@ export default function EditPropertyPage() {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             <div><label htmlFor="bedrooms" className="block text-sm font-medium text-gray-300 mb-1">Bedrooms</label><input type="number" name="bedrooms" id="bedrooms" value={formData.bedrooms} onChange={handleChange} min="0" className="w-full input-style" /></div>
             <div><label htmlFor="bathrooms" className="block text-sm font-medium text-gray-300 mb-1">Bathrooms</label><input type="number" name="bathrooms" id="bathrooms" value={formData.bathrooms} onChange={handleChange} min="0" className="w-full input-style" /></div>
-            <div><label htmlFor="area" className="block text-sm font-medium text-gray-300 mb-1">Area (sqft)</label><input type="number" name="area" id="area" value={formData.area} onChange={handleChange} step="0.01" min="0" className="w-full input-style" /></div>
+            <div><label htmlFor="square_feet" className="block text-sm font-medium text-gray-300 mb-1">Area (sqft)</label><input type="number" name="square_feet" id="square_feet" value={formData.square_feet} onChange={handleChange} step="0.01" min="0" className="w-full input-style" /></div>
           </div>
           <div className="col-span-1 md:col-span-2"><label className="block text-sm font-medium text-gray-300 mb-2">Set Location on Map</label><div id="leaflet-map" style={{ height: '300px' }} className="rounded-md border border-gray-600 mb-2"></div><p className="text-xs text-gray-500 mt-1">Click on the map to update coordinates.</p></div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/frontend/pages/admin/properties/new.js
+++ b/frontend/pages/admin/properties/new.js
@@ -25,7 +25,7 @@ export default function NewPropertyPage() {
     listing_type: listingTypes[0],
     bedrooms: '',
     bathrooms: '',
-    area: '',
+    square_feet: '',
     latitude: '10.4806',
     longitude: '-66.9036',
     is_featured: false,
@@ -192,7 +192,7 @@ export default function NewPropertyPage() {
       price: parseFloat(formData.price) || 0,
       bedrooms: formData.bedrooms ? parseInt(formData.bedrooms) : null,
       bathrooms: formData.bathrooms ? parseInt(formData.bathrooms) : null,
-      area: formData.area ? parseFloat(formData.area) : null,
+      square_feet: formData.square_feet ? parseFloat(formData.square_feet) : null,
       latitude: formData.latitude ? parseFloat(formData.latitude) : null,
       longitude: formData.longitude ? parseFloat(formData.longitude) : null,
       image_url: mainImageUrl || null,
@@ -280,8 +280,8 @@ export default function NewPropertyPage() {
               <input type="number" name="bathrooms" id="bathrooms" value={formData.bathrooms} onChange={handleChange} min="0" className="w-full bg-gray-700 border border-gray-600 text-white rounded-md shadow-sm p-2.5 focus:ring-accent focus:border-accent" />
             </div>
             <div>
-              <label htmlFor="area" className="block text-sm font-medium text-gray-300 mb-1">Area (sqft)</label>
-              <input type="number" name="area" id="area" value={formData.area} onChange={handleChange} step="0.01" min="0" className="w-full bg-gray-700 border border-gray-600 text-white rounded-md shadow-sm p-2.5 focus:ring-accent focus:border-accent" />
+              <label htmlFor="square_feet" className="block text-sm font-medium text-gray-300 mb-1">Area (sqft)</label>
+              <input type="number" name="square_feet" id="square_feet" value={formData.square_feet} onChange={handleChange} step="0.01" min="0" className="w-full bg-gray-700 border border-gray-600 text-white rounded-md shadow-sm p-2.5 focus:ring-accent focus:border-accent" />
             </div>
           </div>
           


### PR DESCRIPTION
## Summary
- add `listing_type` field to `Property` model
- switch CRUD filtering to `square_feet`
- adjust admin property forms to use `square_feet` instead of `area`

## Testing
- `npm run lint` *(fails: `next` not found)*