### PR TITLE
Fix admin background update

### DIFF
--- a/frontend/pages/admin/appearance.js
+++ b/frontend/pages/admin/appearance.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import AdminLayout from '../../components/AdminLayout';
 import { useRouter } from 'next/router';
+import { useSettings } from '../../context/SettingsContext';
 // import Image from 'next/image';
 import { toast } from 'react-toastify';
 
@@ -49,6 +50,7 @@ const colorSections = [
 
 export default function AppearancePage() {
   const router = useRouter();
+  const { refreshSettings } = useSettings();
   const [allSettings, setAllSettings] = useState({}); // To store all settings from API
   const [themeColorSettings, setThemeColorSettings] = useState({}); // Filtered for ThemeColors
   const [homeBgUrl, setHomeBgUrl] = useState('');
@@ -172,7 +174,7 @@ export default function AppearancePage() {
         throw new Error(errData.detail);
       }
       toast.success('Theme colors updated successfully!');
-      // Optionally re-fetch or update context if it doesn't auto-update
+      await refreshSettings();
     } catch (err) {
       console.error(err);
       setError(err.message);
@@ -234,6 +236,7 @@ export default function AppearancePage() {
       setBgFile(null); // Clear file input
       setAllSettings(settingsToUpdate); // Keep allSettings in sync
       toast.success('Background image updated successfully!');
+      await refreshSettings();
       // Apply new background image to the body
       document.body.style.backgroundImage = `url(${uploadedImageUrl})`;
       document.body.style.backgroundSize = 'cover';
@@ -276,6 +279,7 @@ export default function AppearancePage() {
       setHomeBgUrl("");
       setAllSettings(settingsToUpdate); // Keep allSettings in sync
       toast.success('Background image removed.');
+      await refreshSettings();
       // Remove background image from the body
       document.body.style.backgroundImage = 'none';
     } catch (err) {

--- a/frontend/pages/admin/settings.js
+++ b/frontend/pages/admin/settings.js
@@ -12,7 +12,7 @@ const settingCategories = ["General", "Contact", "Social", "AboutPage", "Footer"
 
 export default function AdminSettingsPage() {
   const router = useRouter();
-  const { settings: contextSettings, loading: contextLoading, getSetting } = useSettings(); // Get settings from context
+  const { settings: contextSettings, loading: contextLoading, getSetting, refreshSettings } = useSettings(); // Get settings from context
   const [settingsData, setSettingsData] = useState({}); // Local state for modifications
   const [initialSettingsData, setInitialSettingsData] = useState({}); // To compare for changes
   const [isSaving, setIsSaving] = useState(false);
@@ -107,8 +107,7 @@ export default function AdminSettingsPage() {
       }
       toast.success('Settings updated successfully!');
       setInitialSettingsData(JSON.parse(JSON.stringify(settingsData))); // Update baseline
-      // Optionally, trigger a re-fetch in SettingsContext if needed, or rely on its own refresh mechanism
-      if (window.location) window.location.reload(); // Force reload to see changes reflected by context
+      await refreshSettings();
     } catch (err) {
       console.error(err);
       setError(err.message);


### PR DESCRIPTION
## Summary
- allow SettingsContext to refresh settings
- refresh settings after appearance or admin settings updates

## Testing
- `npm run lint` *(fails: next not found)*